### PR TITLE
Add socket rooms

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,18 +2,29 @@ const app = require('./app'),
   http = require('http').Server(app),
   port = process.env.PORT || 8080,
   io = require('socket.io').listen(http);
-  
+
 io.sockets.on('connection', socket => {
   socket.on('message', msg => {
     io.emit('message', msg);
   });
+
+  socket.on('joinRoom', roomName => {
+    socket.join(roomName);
+
+    socket.on(roomName, message => {
+      io.to(roomName).emit('message', message);
+    }) 
+  });
+
   socket.on('wantToDie', name => {
     console.log(`${name} left`);
     socket.disconnect();
   });
+
   socket.on('clientJoin', name => {
     console.log(`${name} joined`);
   });
 });
+
 http.listen(port, console.log(`Listening on port ${port}`));
 module.exports = http;

--- a/spec/clientSpec.js
+++ b/spec/clientSpec.js
@@ -26,7 +26,7 @@ describe('Client', function() {
   describe('joinRoom', function() {
     it('socket emits welcome', function() {
       spyOn(socket, 'emit');
-      joinRoom();
+      joinRoom('clientJoin');
       expect(socket.emit).toHaveBeenCalled();
     })
   });

--- a/src/client.js
+++ b/src/client.js
@@ -7,8 +7,8 @@ function listenForMessages(cb) {
   socket.on('message', msg => cb(msg));
 }
 
-function joinRoom(name) {
-  socket.emit('clientJoin', name);
+function joinRoom(roomName, name) {
+  socket.emit(roomName, name);
 }
 
 function sendMessage(msg) {


### PR DESCRIPTION
client can now join room by sending a websocket event in format 

  socket.emit('joinRoom', 'roomName')