### PR TITLE
Ignore rules testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
     "type": "git",
     "url": "git+https://github.com/jbropho/final-project-websocket-livechat.git"
   },
+  "nyc": {
+    "exclude": [
+      "**/*.spec.js",
+      "**/*Spec.js",
+      "build"
+    ]
+  },
   "author": "",
   "license": "ISC",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "exclude": [
       "**/*.spec.js",
       "**/*Spec.js",
+      "**/spec",
       "build"
     ]
   },


### PR DESCRIPTION
Add exclude rules to package.json to exclude spec files from coverage reports 